### PR TITLE
Allow to send an empty object as a json parameter in Freshbooks#call

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ Freshbooks.prototype.call = function(method, json, callback) {
     var self = this;
 
     var xml = easyxml.render(json);
-    xml = xml.replace('<request>', '<request method="' + method + '">');
+    xml = xml.replace('<request', '<request method="' + method + '"');
 
     var options = {
         uri: self.url,


### PR DESCRIPTION
Hello,

First of all thanks for this awesome & super-simple library.

Actually, some of the endpoints in the freshbooks API doesn't require any parameters, for example [staff.current](http://developers.freshbooks.com/docs/staff/#staff.current).

Currently the xml request for this:

``` javascript
freshbooks.call("staff.current", {}, function(err, response) {
  console.log(response);
});
```

Is formatted like this:

``` xml
<?xml version='1.0' encoding='utf-8'?>
<request />
```

And the API returns:

``` javascript
{ response: { error: 'Your XML is not formatted correctly.', code: '40010' } }
```

With this simple change you can pass empty objects or even `null` as a second argument to `Freshbooks#call`.
